### PR TITLE
Fix spelling error in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Supported Versions
 
 Only the latest production version of Plasma is supported. Finding security vulnerabilities no longer present in the latest version of Plasma does not help us.
-Contributors on Plasma **MUST** have Two-Factor Authentication enabled. If comprimised they are to be notified via Discord, and permission to push will be revoked.
+Contributors on Plasma **MUST** have Two-Factor Authentication enabled. If compromised they are to be notified via Discord, and permission to push will be revoked.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Corrected spelling of 'compromised' in the security guidelines.